### PR TITLE
BUG Fix missing namespace class imports

### DIFF
--- a/_config/_config.yml
+++ b/_config/_config.yml
@@ -1,3 +1,6 @@
+---
+Name: oauthcontroller
+---
 Bigfork\SilverStripeOAuth\Client\Control\Controller:
   token_handlers:
     loginhandler:

--- a/src/Authenticator/Authenticator.php
+++ b/src/Authenticator/Authenticator.php
@@ -2,10 +2,7 @@
 
 namespace Bigfork\SilverStripeOAuth\Client\Authenticator;
 
-use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Authenticator as SilverStripeAuthenticator;
 use SilverStripe\Security\Member;

--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -3,8 +3,8 @@
 namespace Bigfork\SilverStripeOAuth\Client\Authenticator;
 
 use Bigfork\SilverStripeOAuth\Client\Form\LoginForm;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\Core\Config\Config;
 
 class LoginHandler extends RequestHandler
 {

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -4,10 +4,16 @@ namespace Bigfork\SilverStripeOAuth\Client\Extension;
 
 use Bigfork\SilverStripeOAuth\Client\Model\Passport;
 use SilverStripe\Core\Extension as SilverStripeExtension;
+use SilverStripe\ORM\HasManyList;
 
+/**
+ * @property string $OAuthSource
+ * @property HasManyList|Passport[] Passports()
+ */
 class MemberExtension extends SilverStripeExtension
 {
     /**
+     * @config
      * @var array
      */
     private static $db = [
@@ -15,6 +21,7 @@ class MemberExtension extends SilverStripeExtension
     ];
 
     /**
+     * @config
      * @var array
      */
     private static $has_many = [
@@ -22,12 +29,12 @@ class MemberExtension extends SilverStripeExtension
     ];
 
     /**
-     * Remove this member's OAuth passports on delete
+     * Cleanup passports on user deletion
+     *
+     * @config
+     * @var array
      */
-    public function onBeforeDelete()
-    {
-        foreach ($this->owner->Passports() as $passport) {
-            $passport->delete();
-        }
-    }
+    private static $cascade_deletes = [
+        'Passports',
+    ];
 }

--- a/src/Factory/MemberMapperFactory.php
+++ b/src/Factory/MemberMapperFactory.php
@@ -2,8 +2,8 @@
 
 namespace Bigfork\SilverStripeOAuth\Client\Factory;
 
-use Bigfork\SilverStripeOAuth\Client\Authenticator\Authenticator;
 use Bigfork\SilverStripeOAuth\Client\Mapper\GenericMemberMapper;
+use Bigfork\SilverStripeOAuth\Client\Mapper\MemberMapperInterface;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 
@@ -16,7 +16,7 @@ class MemberMapperFactory
 
     /**
      * @param string $name
-     * @return Bigfork\SilverStripeOAuth\Client\Mapper\MemberMapperInterface
+     * @return MemberMapperInterface
      */
     public function createMapper($name)
     {

--- a/src/Form/LoginForm.php
+++ b/src/Form/LoginForm.php
@@ -3,14 +3,9 @@
 namespace Bigfork\SilverStripeOAuth\Client\Form;
 
 use Bigfork\SilverStripeOAuth\Client\Authenticator\Authenticator;
-use Bigfork\SilverStripeOAuth\Client\Factory\ProviderFactory;
 use Bigfork\SilverStripeOAuth\Client\Helper\Helper;
-use SilverStripe\Control\Controller;
-use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;

--- a/src/Model/OAuthPassport.php
+++ b/src/Model/OAuthPassport.php
@@ -5,6 +5,10 @@ namespace Bigfork\SilverStripeOAuth\Client\Model;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 
+/**
+ * @property string $Identifier
+ * @method Member Member()
+ */
 class Passport extends DataObject
 {
     /**


### PR DESCRIPTION
Other minor fixes:
- Name config block for extension
- Use cascade_deletes
- Minor phpdoc cleanup
- Linting fixes

Only critical fixes included are the fixed up namespace imports, otherwise classes such as `Controller` weren't resolving.