### PR TITLE
Do not force a name, but suggest/inform

### DIFF
--- a/_config/_config.yml
+++ b/_config/_config.yml
@@ -10,13 +10,3 @@ Bigfork\SilverStripeOAuth\Client\Control\Controller:
 SilverStripe\Security\Member:
   extensions:
     - Bigfork\SilverStripeOAuth\Client\Extension\MemberExtension
----
-Name: oauthauthenticator
-After:
-  - '#coresecurity'
----
-SilverStripe\Core\Injector\Injector:
-  SilverStripe\Security\Security:
-    properties:
-      Authenticators:
-        oauth: '%$Bigfork\SilverStripeOAuth\Client\Authenticator\Authenticator'


### PR DESCRIPTION
A new authenticator should not enforce itself, but suggest how to implement in custom code in e.g. the readme. Registering it immediately without prior notice gives people no chance of giving it a different name or have it override existing authenticators.