### PR TITLE
Silverstripe 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "bigfork/silverstripe-oauth": "^2.1",
-        "silverstripe/framework": "^4.4"
+        "bigfork/silverstripe-oauth": "^2",
+        "silverstripe/framework": "^4.4 | ^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
I checked this against an Auth0 installation and it seems to work OK.  

The dependency on `"bigfork/silverstripe-oauth"` doesn't need to be changed, assuming the next stable tag is a minor bump.  I used `composer require "bigfork/silverstripe-oauth:dev-upgrade/ss5 as 2.2"` for testing