### PR TITLE
Fix array to string conversion warning in LoginTokenHandler

### DIFF
--- a/src/Handler/LoginTokenHandler.php
+++ b/src/Handler/LoginTokenHandler.php
@@ -33,7 +33,7 @@ class LoginTokenHandler implements TokenHandler
         // Check whether the member can log in before we proceed
         $result = $member->validateCanLogin();
         if (!$result->isValid()) {
-            return Security::permissionFailure(null, implode('; ', $result->getMessages()));
+            return Security::permissionFailure(null, implode('; ', array_column($result->getMessages(), 'message')));
         }
 
         // Log the member in


### PR DESCRIPTION
`ValidationResult::getMessages()` returns an array of arrays (each containing `message`, `messageType`, and `fieldName` keys), not strings. Passing this directly to `implode()` caused an `E_WARNING: Array to string conversion` and resulted in the permission failure message rendering as `"Array; Array"` instead of the actual validation messages.

Use `array_column()` to extract the message value from each entry before imploding.